### PR TITLE
Fix prepare script for full git clones

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "prepare": "panda codegen && git fetch --unshallow",
+    "prepare": "node scripts/prepare.mjs",
     "dev": "astro dev",
     "start": "astro dev",
     "prebuild": "node scripts/cache-link-banners.mjs",

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process';
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function getGitOutput(args) {
+  return spawnSync('git', args, { encoding: 'utf8' });
+}
+
+run('panda', ['codegen'], { shell: process.platform === 'win32' });
+
+const shallowCheck = getGitOutput(['rev-parse', '--is-shallow-repository']);
+
+if (shallowCheck.status !== 0) {
+  process.exit(shallowCheck.status ?? 1);
+}
+
+// GitHub Actions の shallow clone では、記事更新日の算出に使う gitlog が
+// 過去コミットを読めるように履歴を取得する。一方、ローカルや fetch-depth: 0 の
+// checkout は既に完全なリポジトリなので --unshallow を実行すると失敗する。
+// 事前に shallow かどうかを判定して、環境差で prepare が落ちるのを避ける。
+if (shallowCheck.stdout.trim() === 'true') {
+  run('git', ['fetch', '--unshallow']);
+}


### PR DESCRIPTION
### Motivation
- The original `prepare` script ran `git fetch --unshallow` unconditionally which fails on full repositories with `fatal: --unshallow on a complete repository does not make sense`, causing `pnpm install` / CI to fail.

### Description
- Replace the inline `prepare` command in `package.json` with `node scripts/prepare.mjs`.
- Add `scripts/prepare.mjs` which runs `panda codegen` and checks `git rev-parse --is-shallow-repository` before calling `git fetch --unshallow` so the fetch is only run for shallow checkouts.
- Preserve the original `panda codegen` step while preventing failures on local/full clones and `fetch-depth: 0` checkouts.

### Testing
- Ran `pnpm install --frozen-lockfile` which completed successfully after the change.
- Ran `pnpm build` which completed successfully (build output shows pages and optimized images generated).
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc4005090832aaad0551f92767102)