### PR TITLE
Fix prepare script for non-shallow clones

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "prepare": "panda codegen && git fetch --unshallow",
+    "prepare": "node scripts/prepare.mjs",
     "dev": "astro dev",
     "start": "astro dev",
     "prebuild": "node scripts/cache-link-banners.mjs",

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process';
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function getGitOutput(args) {
+  return spawnSync('git', args, { encoding: 'utf8' });
+}
+
+run('panda', ['codegen'], { shell: process.platform === 'win32' });
+
+const shallowCheck = getGitOutput(['rev-parse', '--is-shallow-repository']);
+
+if (shallowCheck.status !== 0) {
+  process.exit(shallowCheck.status ?? 1);
+}
+
+// GitHub Actions の shallow clone では、記事更新日の算出に使う gitlog が
+// 過去コミットを読めるように履歴を取得する。一方、ローカルや fetch-depth: 0 の
+// checkout は既に完全なリポジトリなので --unshallow を実行すると失敗する。
+// 事前に shallow かどうかを判定して、環境差で prepare が落ちるのを避ける。
+if (shallowCheck.stdout.trim() === 'true') {
+  run('git', ['fetch', '--unshallow']);
+}


### PR DESCRIPTION
Ran by Codex

Summary

    追加で発生していた停止原因は、pnpm v10 が依存パッケージの build script を既定で保留し、@parcel/watcher / esbuild / sharp の install/postinstall が未承認扱いになっていたことでした。

    pnpm-workspace.yaml を追加し、このプロジェクトのビルドに必要なネイティブ依存の build script だけを onlyBuiltDependencies で明示的に許可しました。

    許可リストを広げすぎない意図をコメントとして残し、今後 Dependabot 更新で未知の build script が追加された場合は CI で検知できるようにしています。

Commit / PR

    Commit: 87413ef Allow required pnpm build scripts

    PR 作成済み: Allow required pnpm dependency build scripts

Testing

    ✅ pnpm install --frozen-lockfile

    ✅ pnpm build

    ✅ git diff --check